### PR TITLE
1.8.1

### DIFF
--- a/custom_components/multimatic/binary_sensor.py
+++ b/custom_components/multimatic/binary_sensor.py
@@ -64,12 +64,12 @@ async def async_setup_entry(hass, entry, async_add_entities):
                 sensors.append(RoomDeviceBattery(rooms_coo, device))
                 sensors.append(RoomDeviceConnectivity(rooms_coo, device))
 
-        sensors.extend(
-            [
-                HolidayModeSensor(get_coordinator(hass, HOLIDAY_MODE, entry.unique_id)),
-                QuickModeSensor(get_coordinator(hass, QUICK_MODE, entry.unique_id)),
-            ]
-        )
+    sensors.extend(
+        [
+            HolidayModeSensor(get_coordinator(hass, HOLIDAY_MODE, entry.unique_id)),
+            QuickModeSensor(get_coordinator(hass, QUICK_MODE, entry.unique_id)),
+        ]
+    )
 
     _LOGGER.info("Adding %s binary sensor entities", len(sensors))
 
@@ -445,18 +445,18 @@ class MultimaticErrors(MultimaticEntity, BinarySensorEntity):
         """Return the state attributes."""
         state_attributes = {}
         if self.coordinator.data.errors:
+            errors = []
             for error in self.coordinator.data.errors:
-                state_attributes.update(
+                errors.append(
                     {
-                        error.status_code: {
-                            "status_code": error.status_code,
-                            "title": error.title,
-                            "timestamp": error.timestamp,
-                            "description": error.description,
-                            "device_name": error.device_name,
-                        }
+                        "status_code": error.status_code,
+                        "title": error.title,
+                        "timestamp": error.timestamp,
+                        "description": error.description,
+                        "device_name": error.device_name,
                     }
                 )
+            state_attributes["errors"] = errors
         return state_attributes
 
     @property

--- a/custom_components/multimatic/manifest.json
+++ b/custom_components/multimatic/manifest.json
@@ -14,6 +14,6 @@
   "codeowners": [
     "@thomasgermain"
   ],
-  "version": "1.8.0",
+  "version": "1.8.1",
   "iot_class": "cloud_polling"
 }


### PR DESCRIPTION
- fix missing holiday and quick_mode binary sensor
- errors in binary_sensor.multimatic_errors are now inside an `errors` state_attributes