### PR TITLE
Statistic Values - remove last_reset for Release 2022.02

### DIFF
--- a/custom_components/multimatic/sensor.py
+++ b/custom_components/multimatic/sensor.py
@@ -232,11 +232,6 @@ class EmfReportSensor(MultimaticEntity, SensorEntity):
         return self._name
 
     @property
-    def last_reset(self) -> datetime.datetime:
-        """Return the time when the sensor was last reset, if any."""
-        return utc_from_timestamp(0)
-
-    @property
     def state_class(self) -> str:
         """Return the state class of this entity."""
         return STATE_CLASS_TOTAL_INCREASING


### PR DESCRIPTION
With 2022.02 last reset is not allowed in STATE_CLASS_TOTAL_INCREASING

Example:
Entity sensor.multimatic_water_verbrauch (<class 'custom_components.multimatic.sensor.EmfReportSensor'>) with state_class total_increasing has set last_reset. Setting last_reset for entities with state_class other than 'total' is not supported. Please update your configuration if state_class is manually configured, otherwise report it to the custom component author.