### PR TITLE
fix: more hvac message

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ Ideas are welcome ! Don't hesitate to create issue to suggest something, it will
 
 **This integration is NOT compatible with sensoAPP, only with multiMATIC app.**
 
+**This integration is NOT likely to be compatible with VR921 (even if you use multiMATIC app). You may still have
+some entities, but not all.**
+
 ## Installations
 - Through HACS [custom repositories](https://hacs.xyz/docs/faq/custom_repositories/) !
 - Otherwise, download the zip from the latest release and copy `multimatic` folder and put it inside your `custom_components` folder.

--- a/custom_components/multimatic/manifest.json
+++ b/custom_components/multimatic/manifest.json
@@ -5,7 +5,7 @@
   "documentation": "https://github.com/thomasgermain/vaillant-component",
   "issue_tracker": "https://github.com/thomasgermain/vaillant-component/issues",
   "requirements": [
-    "pymultimatic==0.6.7"
+    "pymultimatic==0.6.8"
   ],
   "ssdp": [],
   "zeroconf": [],


### PR DESCRIPTION
Bump pymultimatic to 0.6.8, in order to handle more hvac message from the API.

See https://github.com/thomasgermain/vaillant-component/issues/147

(Also add a note, stating that VR921 is not totally supported, since the API doesn't seem to be the same, see https://github.com/thomasgermain/vaillant-component/issues/149 & https://github.com/thomasgermain/vaillant-component/issues/145)